### PR TITLE
fix falsy values evaluation

### DIFF
--- a/src/ReactReplJS.js
+++ b/src/ReactReplJS.js
@@ -17,9 +17,7 @@ async function execAndGetLine(execLine) {
   if (!execLine.trim()) return []
   try {
     const evalOutput = await scopeEval(window, execLine)
-    if (evalOutput) {
-      return { type: "output", value: prettyFormat(evalOutput) }
-    }
+    return { type: "output", value: prettyFormat(evalOutput) }
   } catch (e) {
     return { type: "error", value: e }
   }

--- a/src/stories/ReactReplJS.stories.js
+++ b/src/stories/ReactReplJS.stories.js
@@ -11,6 +11,6 @@ export const Main = () => (
   <ReactReplJS
     title="<ReactReplJS />"
     height={300}
-    initiallyExecute={["a = 3", "b = 4", "a * b"]}
+    initiallyExecute={["a = 3", "b = 4", "a * b", "1 - 1"]}
   />
 )


### PR DESCRIPTION
# What is this PR for?

On the function `execAndGetLine` is an if statement which can detonate errors due to no all function branches return a result. Furthermore, the errors could be detonated by a falsy value which could be the expected result for the user. 

```javascript
if (evalOutput) {
  return { type: "output", value: prettyFormat(evalOutput) }
}
```

In example, if the user writes `1 - 1` which should return `0` will end up breaking the component due to receiving undefined during rendering lines on the terminal.

Maybe the if statement was required for other reasons. If that's the case I'm happy to help, otherwise I think this pull request has everything need to make it work.

Thanks for creating this component!!

# What have been done in this PR?

1. Fix the falsy values evaluation in the REPL component.
2. Add one more line on the component story  for checking a falsy value will be correctly evaluated.